### PR TITLE
v1.3.1: WoW 12.0.1 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.1] - WoW 12.0.1 Compatibility
+
+### Changed
+- Updated Interface version to 120001 for WoW 12.0.1 (Midnight launch)
+- Fixed addon version string being out of sync between TOC and runtime
+
 ## [1.3.0] - Hide Filter & Discord Notifications
 
 ### Added

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -5,7 +5,7 @@ _G.MinimapOrganizer = MO
 
 -- Addon metadata
 MO.name = ADDON_NAME
-MO.version = "1.1.0"
+MO.version = "1.3.1"
 
 -- System buttons to never collect (built-in WoW and common addon frames)
 MO.SYSTEM_IGNORE = {

--- a/MinimapOrganizer.toc
+++ b/MinimapOrganizer.toc
@@ -1,8 +1,8 @@
-## Interface: 120000
+## Interface: 120001
 ## Title: MinimapOrganizer
 ## Notes: Collects minimap buttons into a movable, organized window with categories and favorites
 ## Author: atmuccio
-## Version: 1.3.0
+## Version: 1.3.1
 ## SavedVariablesPerCharacter: MinimapOrganizerDB
 ## IconTexture: Interface\ICONS\Garrison_Building_Storehouse
 ## Category: Map


### PR DESCRIPTION
## Summary
- Updated TOC Interface version from `120000` to `120001` for WoW 12.0.1 (Midnight launch)
- Bumped addon version to `1.3.1` in TOC and Init.lua
- Fixed runtime version string in `Core/Init.lua` being out of sync (`1.1.0` → `1.3.1`)
- Added changelog entry for v1.3.1

## Compatibility
Verified all addon APIs against [Patch 12.0.1 API changes](https://warcraft.wiki.gg/wiki/Patch_12.0.1/API_changes) — no breaking changes affect MinimapOrganizer. The 12.0.1 changes are focused on combat encounter APIs and housing features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)