### PR TITLE
v1.5.0: WoW 12.0.5 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.0] - 2026-04-21
+
+### Changed
+- Updated Interface version to 120005 for WoW 12.0.5 (Lingering Shadows)
+- Fixed addon version string being out of sync between TOC and runtime
+
 ## [1.4.0] - Preserve Original Button Behavior
 
 ### Added

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -5,7 +5,7 @@ _G.MinimapOrganizer = MO
 
 -- Addon metadata
 MO.name = ADDON_NAME
-MO.version = "1.3.1"
+MO.version = "1.5.0"
 
 -- System buttons to never collect (built-in WoW and common addon frames)
 MO.SYSTEM_IGNORE = {

--- a/MinimapOrganizer.toc
+++ b/MinimapOrganizer.toc
@@ -1,8 +1,8 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: MinimapOrganizer
 ## Notes: Collects minimap buttons into a movable, organized window with categories and favorites
 ## Author: atmuccio
-## Version: 1.4.0
+## Version: 1.5.0
 ## SavedVariablesPerCharacter: MinimapOrganizerDB
 ## IconTexture: Interface\ICONS\Garrison_Building_Storehouse
 ## Category: Map


### PR DESCRIPTION
## Summary
- Updated Interface version from `120001` to `120005` for WoW 12.0.5 (Lingering Shadows)
- Fixed addon version string in `Core/Init.lua` being out of sync (`1.3.1` → `1.5.0`)
- No API changes required — no deprecated or removed APIs affect this addon
- Updated changelog

## Test plan
- [ ] Verify addon loads without errors on WoW 12.0.5
- [ ] Verify minimap button collection and display works correctly
- [ ] Verify manage mode, favorites, categories, and settings all function
- [ ] Verify `/mo` slash commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)