### PR TITLE
v1.5.1: WoW 12.0.7 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.1] - 2026-06-17
+
+### Changed
+- Updated Interface version to 120007 for WoW 12.0.7 (Midnight: Revelations)
+
 ## [1.5.0] - 2026-04-21
 
 ### Changed

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -5,7 +5,7 @@ _G.MinimapOrganizer = MO
 
 -- Addon metadata
 MO.name = ADDON_NAME
-MO.version = "1.5.0"
+MO.version = "1.5.1"
 
 -- System buttons to never collect (built-in WoW and common addon frames)
 MO.SYSTEM_IGNORE = {

--- a/MinimapOrganizer.toc
+++ b/MinimapOrganizer.toc
@@ -1,8 +1,8 @@
-## Interface: 120005
+## Interface: 120007
 ## Title: MinimapOrganizer
 ## Notes: Collects minimap buttons into a movable, organized window with categories and favorites
 ## Author: atmuccio
-## Version: 1.5.0
+## Version: 1.5.1
 ## SavedVariablesPerCharacter: MinimapOrganizerDB
 ## IconTexture: Interface\ICONS\Garrison_Building_Storehouse
 ## Category: Map


### PR DESCRIPTION
## Summary
WoW 12.0.7 (Midnight: Revelations) compatibility update.

- Bump Interface version `120005` → `120007`
- Bump runtime `MO.version` string `1.5.0` → `1.5.1` to match TOC
- No code changes required — scanned all Lua for removed/deprecated 12.0.7 APIs (removed `Minimap:Set*` texture setters, `SetTooltipMoney`/`MoneyFrame`, deprecated globals); none in use
- Changelog entry for v1.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)